### PR TITLE
Simplify printing of error causes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,12 +61,9 @@ pub fn main() {
     match execute() {
         Ok(()) => {},
         Err(err) => {
-            use std::error::Error;
             println!("error: {}", err);
-            let mut cause = err.cause();
-            while let Some(the_cause) = cause {
-                println!("  caused by: {}", the_cause);
-                cause = the_cause.cause();
+            for cause in err.iter().skip(1) {
+                println!("  caused by: {}", cause);
             }
             process::exit(1);
         }


### PR DESCRIPTION
We may iterate over the causes using a `for` loop and `iter()`. This shortens the code, removes the need to use two similarly named variables (`cause` and `the_cause`), and removes the need for a `use` of `std::error::Error`.